### PR TITLE
Build NixOS kernel with SEV support

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -20,7 +20,7 @@ let
         };
     });
 in {
-  imports = [ ./hardware-configuration.nix ./sshonly.nix ./ddns.nix ./podman.nix ];
+  imports = [ ./hardware-configuration.nix ./sshonly.nix ./ddns.nix ./podman.nix ./sev.nix ];
   system.stateVersion = "19.09";
 
   boot.loader.systemd-boot.enable = true;
@@ -52,7 +52,7 @@ in {
       ];
     };
     npmccallum = {
-      shell = posh "" "--device /dev/kvm" "quay.io/enarx/fedora";
+      shell = posh "" "--device /dev/kvm" "--device /dev/sev" "quay.io/enarx/fedora";
       isNormalUser = true;
       subUidRanges = [{ startUid = 100000; count = 10000; }];
       subGidRanges = [{ startGid = 100000; count = 10000; }];
@@ -61,7 +61,7 @@ in {
       ];
     };
     mbestavros = {
-      shell = posh "" "--device /dev/kvm" "quay.io/enarx/fedora";
+      shell = posh "" "--device /dev/kvm" "--device /dev/sev" "quay.io/enarx/fedora";
       isNormalUser = true;
       subUidRanges = [{ startUid = 110000; count = 10000; }];
       subGidRanges = [{ startGid = 110000; count = 10000; }];
@@ -70,7 +70,7 @@ in {
       ];
     };
     lsturman = {
-      shell = posh "" "--device /dev/kvm" "quay.io/enarx/fedora";
+      shell = posh "" "--device /dev/kvm" "--device /dev/sev" "quay.io/enarx/fedora";
       isNormalUser = true;
       subUidRanges = [{ startUid = 120000; count = 10000; }];
       subGidRanges = [{ startGid = 120000; count = 10000; }];
@@ -79,7 +79,7 @@ in {
       ];
     };
     ckuehl = {
-      shell = posh "" "--device /dev/kvm" "quay.io/enarx/fedora";
+      shell = posh "" "--device /dev/kvm" "--device /dev/sev" "quay.io/enarx/fedora";
       isNormalUser = true;
       subUidRanges = [{ startUid = 130000; count = 10000; }];
       subGidRanges = [{ startGid = 130000; count = 10000; }];

--- a/sev.nix
+++ b/sev.nix
@@ -1,0 +1,16 @@
+{ config, pkgs, ... }:
+
+{
+  services.udev.extraRules = ''KERNEL=="sev", MODE="0666"'';
+
+  boot.kernelPatches = [{
+    name = "kvm-amd-sev";
+    patch = null;
+    extraConfig = ''
+          CRYPTO_DEV_CCP y
+          CRYPTO_DEV_CCP_DD m
+          CRYPTO_DEV_SP_PSP y
+          KVM_AMD_SEV y
+          '';
+  }];
+}


### PR DESCRIPTION
Use the boot.kernelPatches option to enable the requisite config change
for SEV support.

Reference: https://nixos.wiki/wiki/Linux_kernel#Custom_configuration