### PR TITLE
Enable the now-supported SEV functionality in the kernel

### DIFF
--- a/sev.nix
+++ b/sev.nix
@@ -13,4 +13,5 @@
           KVM_AMD_SEV y
           '';
   }];
+  boot.kernelParams = [ "mem_encrypt=on" "kvm_amd.sev=1" ];
 }


### PR DESCRIPTION
Since it's turned off by default even though it exists.

Test: 

```
# cat /sys/module/kvm_amd/parameters/sev 
```

Expected result: 1
Actual result: 0